### PR TITLE
Feat: 회원가입 Firestore 연동

### DIFF
--- a/src/pages/SignIn/index.tsx
+++ b/src/pages/SignIn/index.tsx
@@ -10,7 +10,7 @@ import Container from '@mui/material/Container';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
 import { useNavigate, useLocation } from 'react-router-dom';
 
-import { auth } from '../../utils/firebase';
+import { auth, addUser } from '../../utils/firebase';
 import { createUserWithEmailAndPassword } from 'firebase/auth';
 
 const defaultTheme = createTheme();
@@ -31,10 +31,24 @@ export default function SignIn() {
         const passwordEntry = data.get('password');
         const password = passwordEntry !== null ? passwordEntry.toString() : '';
 
+        const nameEntry = data.get('name');
+        const name = nameEntry !== null ? nameEntry.toString() : '';
+
         // firebase Auth 등록
         createUserWithEmailAndPassword(auth, email, password)
             .then((userCredential) => {
                 const user = userCredential.user;
+
+                const value = {
+                    name: name,
+                    email: email,
+                    info: `안녕하세요 ${name}입니다.`,
+                    login: false,
+                    imageURL:
+                        'https://firebasestorage.googleapis.com/v0/b/wiki-for-fastcampus.appspot.com/o/images%2Fprofile.jpeg?alt=media&token=29da086e-74a8-445c-99b3-7332569544f7',
+                    timelog: [],
+                };
+                addUser(user.uid, value);
 
                 // 회원가입 성공시 redirect
                 navigate('/login', { state: pathname });
@@ -68,6 +82,17 @@ export default function SignIn() {
                             margin="normal"
                             required
                             fullWidth
+                            name="name"
+                            label="name"
+                            type="text"
+                            id="name"
+                            autoComplete="name"
+                        />
+
+                        <TextField
+                            margin="normal"
+                            required
+                            fullWidth
                             id="email"
                             label="Email Address"
                             name="email"
@@ -84,6 +109,7 @@ export default function SignIn() {
                             id="password"
                             autoComplete="current-password"
                         />
+
                         <Button type="submit" fullWidth variant="contained" sx={{ mt: 3, mb: 2 }}>
                             Sign In
                         </Button>

--- a/src/utils/firebase.ts
+++ b/src/utils/firebase.ts
@@ -158,3 +158,12 @@ export const updateFieldKeyInDoc = async (
         throw error;
     }
 };
+
+export const addUser = async (uid: string, value: any) => {
+    try {
+        const addUserFirestore = await setDoc(doc(firestore, 'user', uid), value);
+    } catch (error) {
+        console.error('계정 등록에 실패했습니다.', error);
+        throw error;
+    }
+};


### PR DESCRIPTION
## Summary
회원가입 Firestore 연동

## Decribe details
        modified:   src/pages/SignIn/index.tsx
        modified:   src/utils/firebase.ts

<img width="1920" alt="스크린샷 2023-09-19 12 31 09" src="https://github.com/2weeks-team/2weeks-team/assets/57976371/5151d794-64cc-466a-af96-04d5221b9acf">

<img width="1273" alt="image" src="https://github.com/2weeks-team/2weeks-team/assets/57976371/1303e694-1f81-43cd-b61d-e61a42f30e19">

firestore에는  아래 형식으로 login : false, imageURL은 기본 이미지가 default 값으로 들어갑니다.

```
const value = {
                    name: name,
                    email: email,
                    info: `안녕하세요 ${name}입니다.`,
                    login: false,
                    imageURL:
                        'https://firebasestorage.googleapis.com/v0/b/wiki-for-fastcampus.appspot.com/o/images%2Fprofile.jpeg?alt=media&token=29da086e-74a8-445c-99b3-7332569544f7',
                    timelog: [],
                };
```


## Jira link

## PR guidline check list

Plz check if your code fulfills the following requirements.

-   [ ] The Commit message follows our conventions.
-   [ ] The File follows folder structure.
-   [ ] The PR title follows the convention rule.

## any comment...
